### PR TITLE
handle fields that show up multiple times

### DIFF
--- a/app/internal/data_manager.py
+++ b/app/internal/data_manager.py
@@ -1216,6 +1216,7 @@ class DataManager:
 
         ## match record attribute to each processor attribute
         sorted_attributes = []
+        ## TODO: make sure we add EACH INSTANCE of attribute to sorted_attributes
         for each in processor_attributes:
             attribute_name = each["name"]
             attribute = next(

--- a/app/internal/data_manager.py
+++ b/app/internal/data_manager.py
@@ -6,6 +6,7 @@ import csv
 import json
 from enum import Enum
 import threading
+import traceback
 
 from typing import Union, List
 from pydantic import BaseModel
@@ -18,6 +19,7 @@ from app.internal.image_handling import (
     generate_download_signed_url_v4,
     delete_google_storage_directory,
 )
+import app.internal.util as util
 
 
 _log = logging.getLogger(__name__)
@@ -712,10 +714,13 @@ class DataManager:
 
         ## sort record attributes
         try:
-            sorted_attributes = self.sortRecordAttributes(document, rg)
+            google_id = rg["processorId"]
+            processor_doc = self.db.processors.find({"google_id": google_id}).next()
+            sorted_attributes = util.sortRecordAttributes(document["attributesList"], processor_doc)
             document["attributesList"] = sorted_attributes
         except Exception as e:
             _log.error(f"unable to sort attributes: {e}")
+            _log.error(traceback.format_exc())
 
         return document, not attained_lock
 
@@ -1204,32 +1209,6 @@ class DataManager:
         except Exception as e:
             _log.error(f"unable to check validity of image: {e}")
             return False
-
-    def sortRecordAttributes(self, record, rg):
-        # start_time = time.time()
-
-        ## get processor attributes
-        google_id = rg["processorId"]
-        processor_doc = self.db.processors.find({"google_id": google_id}).next()
-        processor_attributes = processor_doc["attributes"]
-        attributes = record["attributesList"]
-
-        ## match record attribute to each processor attribute
-        sorted_attributes = []
-        ## TODO: make sure we add EACH INSTANCE of attribute to sorted_attributes
-        for each in processor_attributes:
-            attribute_name = each["name"]
-            attribute = next(
-                (item for item in attributes if item["key"] == attribute_name), None
-            )
-            if attribute is None:
-                _log.info(f"{attribute_name} is None")
-            else:
-                sorted_attributes.append(attribute)
-
-        # end_time = time.time()
-        # _log.info(f"sorting process took {end_time-start_time} seconds")
-        return sorted_attributes
 
     def recordHistory(
         self,

--- a/app/internal/data_manager.py
+++ b/app/internal/data_manager.py
@@ -716,7 +716,9 @@ class DataManager:
         try:
             google_id = rg["processorId"]
             processor_doc = self.db.processors.find({"google_id": google_id}).next()
-            sorted_attributes = util.sortRecordAttributes(document["attributesList"], processor_doc)
+            sorted_attributes = util.sortRecordAttributes(
+                document["attributesList"], processor_doc
+            )
             document["attributesList"] = sorted_attributes
         except Exception as e:
             _log.error(f"unable to sort attributes: {e}")

--- a/app/internal/data_manager.py
+++ b/app/internal/data_manager.py
@@ -669,7 +669,7 @@ class DataManager:
             return None, None
         image_urls = []
         for image in document.get("image_files", []):
-            if self.imageIsValid(image):
+            if util.imageIsValid(image):
                 image_urls.append(
                     generate_download_signed_url_v4(
                         document["record_group_id"], document["_id"], image
@@ -1172,14 +1172,6 @@ class DataManager:
             )
         return output_file
 
-    def deleteFiles(self, filepaths, sleep_time=5):
-        _log.info(f"deleting files: {filepaths} in {sleep_time} seconds")
-        time.sleep(sleep_time)
-        for filepath in filepaths:
-            if os.path.isfile(filepath):
-                os.remove(filepath)
-                _log.info(f"deleted {filepath}")
-
     def checkProjectValidity(self, projectId):
         try:
             project_id = ObjectId(projectId)
@@ -1197,18 +1189,6 @@ class DataManager:
         rg = self.getDocument("record_groups", {"_id": rg_id})
         if rg is not None:
             return True
-
-    def imageIsValid(self, image):
-        ## some broken records have letters saved where image names should be
-        ## for now, just ensure that the name is at least 3 characters long
-        try:
-            if len(image) > 2:
-                return True
-            else:
-                return False
-        except Exception as e:
-            _log.error(f"unable to check validity of image: {e}")
-            return False
 
     def recordHistory(
         self,

--- a/app/internal/image_handling.py
+++ b/app/internal/image_handling.py
@@ -427,11 +427,13 @@ def process_image(
                     "page": None,
                 }
             )
-    
+
     ## double check found attributes to see if we found anything that was NOT in the processor's attributes
     for attr in found_attributes:
         if attr not in processor_attributes_list:
-            _log.info(f"{attr} was not in processor's attributes. adding this to the end of the sorted attributes list")
+            _log.info(
+                f"{attr} was not in processor's attributes. adding this to the end of the sorted attributes list"
+            )
             indexes = found_attributes[attr]
             for idx in indexes:
                 sortedAttributesList.append(attributesList[idx])

--- a/app/internal/image_handling.py
+++ b/app/internal/image_handling.py
@@ -16,6 +16,7 @@ import zipfile
 import mimetypes
 
 from app.internal.bulk_upload import upload_documents_from_directory
+import app.internal.util as util
 
 _log = logging.getLogger(__name__)
 
@@ -169,7 +170,7 @@ def process_document(
     if original_output_path not in output_path:
         files_to_delete.append(original_output_path)
     background_tasks.add_task(
-        data_manager.deleteFiles, filepaths=files_to_delete, sleep_time=60
+        util.deleteFiles, filepaths=files_to_delete, sleep_time=60
     )
     return {"record_id": new_record_id}
 

--- a/app/internal/util.py
+++ b/app/internal/util.py
@@ -1,7 +1,9 @@
 import time
 import os
 import logging
+
 _log = logging.getLogger(__name__)
+
 
 def sortRecordAttributes(attributes, processor, keep_all_attributes=True):
     processor_attributes = processor["attributes"]
@@ -24,10 +26,13 @@ def sortRecordAttributes(attributes, processor, keep_all_attributes=True):
         for attr in attributes:
             attribute_name = attr["key"]
             if attribute_name not in processor_attributes_list:
-                _log.debug(f"{attribute_name} was not in processor's attributes. adding this to the end of the sorted attributes list")
+                _log.debug(
+                    f"{attribute_name} was not in processor's attributes. adding this to the end of the sorted attributes list"
+                )
                 sorted_attributes.append(attr)
 
     return sorted_attributes
+
 
 def imageIsValid(image):
     ## some broken records have letters saved where image names should be
@@ -40,6 +45,7 @@ def imageIsValid(image):
     except Exception as e:
         _log.error(f"unable to check validity of image: {e}")
         return False
+
 
 def deleteFiles(filepaths, sleep_time=5):
     _log.info(f"deleting files: {filepaths} in {sleep_time} seconds")

--- a/app/internal/util.py
+++ b/app/internal/util.py
@@ -1,28 +1,50 @@
+import time
+import os
 import logging
 _log = logging.getLogger(__name__)
 
 def sortRecordAttributes(attributes, processor, keep_all_attributes=True):
-        processor_attributes = processor["attributes"]
+    processor_attributes = processor["attributes"]
 
-        ## match record attribute to each processor attribute
-        sorted_attributes = []
-        processor_attributes_list = []
-        for each in processor_attributes:
-            attribute_name = each["name"]
-            processor_attributes_list.append(attribute_name)
-            attribute = next(
-                (item for item in attributes if item["key"] == attribute_name), None
-            )
-            if attribute is None:
-                _log.info(f"{attribute_name} is None")
-            else:
-                sorted_attributes.append(attribute)
+    ## match record attribute to each processor attribute
+    sorted_attributes = []
+    processor_attributes_list = []
+    for each in processor_attributes:
+        attribute_name = each["name"]
+        processor_attributes_list.append(attribute_name)
+        attribute = next(
+            (item for item in attributes if item["key"] == attribute_name), None
+        )
+        if attribute is None:
+            _log.info(f"{attribute_name} is None")
+        else:
+            sorted_attributes.append(attribute)
 
-        if keep_all_attributes:
-            for attr in attributes:
-                attribute_name = attr["key"]
-                if attribute_name not in processor_attributes_list:
-                    _log.debug(f"{attribute_name} was not in processor's attributes. adding this to the end of the sorted attributes list")
-                    sorted_attributes.append(attr)
+    if keep_all_attributes:
+        for attr in attributes:
+            attribute_name = attr["key"]
+            if attribute_name not in processor_attributes_list:
+                _log.debug(f"{attribute_name} was not in processor's attributes. adding this to the end of the sorted attributes list")
+                sorted_attributes.append(attr)
 
-        return sorted_attributes
+    return sorted_attributes
+
+def imageIsValid(image):
+    ## some broken records have letters saved where image names should be
+    ## for now, just ensure that the name is at least 3 characters long
+    try:
+        if len(image) > 2:
+            return True
+        else:
+            return False
+    except Exception as e:
+        _log.error(f"unable to check validity of image: {e}")
+        return False
+
+def deleteFiles(filepaths, sleep_time=5):
+    _log.info(f"deleting files: {filepaths} in {sleep_time} seconds")
+    time.sleep(sleep_time)
+    for filepath in filepaths:
+        if os.path.isfile(filepath):
+            os.remove(filepath)
+            _log.info(f"deleted {filepath}")

--- a/app/internal/util.py
+++ b/app/internal/util.py
@@ -1,0 +1,28 @@
+import logging
+_log = logging.getLogger(__name__)
+
+def sortRecordAttributes(attributes, processor, keep_all_attributes=True):
+        processor_attributes = processor["attributes"]
+
+        ## match record attribute to each processor attribute
+        sorted_attributes = []
+        processor_attributes_list = []
+        for each in processor_attributes:
+            attribute_name = each["name"]
+            processor_attributes_list.append(attribute_name)
+            attribute = next(
+                (item for item in attributes if item["key"] == attribute_name), None
+            )
+            if attribute is None:
+                _log.info(f"{attribute_name} is None")
+            else:
+                sorted_attributes.append(attribute)
+
+        if keep_all_attributes:
+            for attr in attributes:
+                attribute_name = attr["key"]
+                if attribute_name not in processor_attributes_list:
+                    _log.debug(f"{attribute_name} was not in processor's attributes. adding this to the end of the sorted attributes list")
+                    sorted_attributes.append(attr)
+
+        return sorted_attributes

--- a/app/routers/router.py
+++ b/app/routers/router.py
@@ -18,6 +18,7 @@ from fastapi.security import OAuth2PasswordBearer
 
 from app.internal.data_manager import data_manager, Roles
 from app.internal.image_handling import process_document, process_zip
+import app.internal.util as util
 import app.internal.auth as auth
 
 _log = logging.getLogger(__name__)
@@ -654,7 +655,7 @@ async def download_records(
     )
     ## remove file after 30 seconds to allow for the user download to finish
     background_tasks.add_task(
-        data_manager.deleteFiles, filepaths=[export_file], sleep_time=30
+        util.deleteFiles, filepaths=[export_file], sleep_time=30
     )
     return export_file
 

--- a/app/routers/router.py
+++ b/app/routers/router.py
@@ -654,9 +654,7 @@ async def download_records(
         keep_all_columns=keep_all_columns,
     )
     ## remove file after 30 seconds to allow for the user download to finish
-    background_tasks.add_task(
-        util.deleteFiles, filepaths=[export_file], sleep_time=30
-    )
+    background_tasks.add_task(util.deleteFiles, filepaths=[export_file], sleep_time=30)
     return export_file
 
 


### PR DESCRIPTION
handles #70 
- properly handle multiple instances of fields
- add on any fields that are found but NOT a part of the processor's attribute list (so far, this has only been one field that was typo'ed, but good to do this just incase we misspell processor fields in the future)
