### PR TITLE
Defective Categories, parse API numbers

### DIFF
--- a/app/internal/data_manager.py
+++ b/app/internal/data_manager.py
@@ -930,7 +930,9 @@ class DataManager:
                     update_type == "review_status"
                     and new_data.get("review_status", None) == "defective"
                 ):
-                    data_update["defective_categories"] = new_data.get("defective_categories", [])
+                    data_update["defective_categories"] = new_data.get(
+                        "defective_categories", []
+                    )
                 update_query = {"$set": data_update}
             if not forceUpdate:
                 ## fetch record's current data so we know what changed in the future

--- a/app/internal/data_manager.py
+++ b/app/internal/data_manager.py
@@ -926,6 +926,11 @@ class DataManager:
                     and new_data.get("review_status", None) == "unreviewed"
                 ):
                     data_update = self.resetRecord(record_id, new_data, user)
+                elif (
+                    update_type == "review_status"
+                    and new_data.get("review_status", None) == "defective"
+                ):
+                    data_update["defective_categories"] = new_data.get("defective_categories", [])
                 update_query = {"$set": data_update}
             if not forceUpdate:
                 ## fetch record's current data so we know what changed in the future

--- a/app/internal/image_handling.py
+++ b/app/internal/image_handling.py
@@ -130,6 +130,7 @@ def process_document(
     try:
         # parse api number from filename
         api_number = filename.split("_")[0]
+        api_number = int(api_number)
     except Exception as e:
         _log.info(f"unable to parse api number")
         api_number = None

--- a/app/internal/image_handling.py
+++ b/app/internal/image_handling.py
@@ -127,11 +127,18 @@ def process_document(
     else:
         output_paths = [original_output_path]
 
+    try:
+        # parse api number from filename
+        api_number = filename.split("_")[0]
+    except Exception as e:
+        _log.info(f"unable to parse api number")
+        api_number = None
     ## add record to DB without attributes
     new_record = {
         "record_group_id": rg_id,
         "name": filename,
         "filename": f"{filename}{file_ext}",
+        "api_number": api_number,
         "contributor": user_info,
         "status": "processing",
         "review_status": "unreviewed",


### PR DESCRIPTION
- when updating a record to be defective, add defective categories key
- parse API number when creating new records