### PR TITLE
Handle subattributes in python schema

### DIFF
--- a/app/internal/image_handling.py
+++ b/app/internal/image_handling.py
@@ -430,7 +430,9 @@ def process_image(
             indexes = found_attributes[attr]
             for idx in indexes:
                 sortedAttributesList.append(attributesList[idx])
-        elif "::" not in attr: ## :: indicates it is a subattribute. these are handled by parent attribut
+        elif (
+            "::" not in attr
+        ):  ## :: indicates it is a subattribute. these are handled by parent attribut
             sortedAttributesList.append(
                 {
                     "key": attr,

--- a/app/internal/image_handling.py
+++ b/app/internal/image_handling.py
@@ -428,11 +428,9 @@ def process_image(
         processor_attributes_list.append(attr)
         if attr in found_attributes:
             indexes = found_attributes[attr]
-            # if len(indexes) > 1:
-            #     print(f"found multiple for {attr}")
             for idx in indexes:
                 sortedAttributesList.append(attributesList[idx])
-        else:
+        elif "::" not in attr: ## :: indicates it is a subattribute. these are handled by parent attribut
             sortedAttributesList.append(
                 {
                     "key": attr,

--- a/app/internal/util.py
+++ b/app/internal/util.py
@@ -241,13 +241,13 @@ def cleanRecordAttribute(processor_attributes, attribute, subattributeKey=None):
         else:
             _log.info(f"no cleaning function with name: {cleaning_function_name}")
 
-    subattributes = attribute.get("subattributes", None)
-    if subattributes:
-        for subattribute in subattributes:
-            subattribute_key = f"{attribute_key}::{subattribute['key']}"
-            cleanRecordAttribute(
-                processor_attributes, subattribute, subattributeKey=subattribute_key
-            )
+        subattributes = attribute.get("subattributes", None)
+        if subattributes:
+            for subattribute in subattributes:
+                subattribute_key = f"{attribute_key}::{subattribute['key']}"
+                cleanRecordAttribute(
+                    processor_attributes, subattribute, subattributeKey=subattribute_key
+                )
 
     else:
         _log.info(f"no schema found for {attribute_key}")


### PR DESCRIPTION
- in the schema, subattributes are defined as \<PARENT\>::\<CHILD\>, but we store these as subfields of the parent field