### PR TITLE
Improve fetching efficiency

### DIFF
--- a/app/internal/data_manager.py
+++ b/app/internal/data_manager.py
@@ -549,6 +549,7 @@ class DataManager:
                 _log.error(f"unable to get record groups for project {project_id}: {e}")
         return record_groups_list
 
+    @time_it
     def fetchRecords(
         self,
         sort_by=["dateCreated", 1],

--- a/app/internal/data_manager.py
+++ b/app/internal/data_manager.py
@@ -664,6 +664,7 @@ class DataManager:
 
         return {"project": project, "record_groups": record_groups}
 
+    @time_it
     def fetchColumnData(self, location, _id):
         if location == "project" or location == "team":
             columns = set()

--- a/app/internal/data_manager.py
+++ b/app/internal/data_manager.py
@@ -519,6 +519,7 @@ class DataManager:
             return document
         return None
 
+    @time_it
     def fetchProjects(self, user):
         user_projects = self.getUserProjectList(user)
         projects = []
@@ -718,6 +719,7 @@ class DataManager:
             roles.append(document)
         return roles
 
+    @time_it
     def fetchProjectData(
         self, project_id, user, page, records_per_page, sort_by, filter_by
     ):

--- a/app/internal/util.py
+++ b/app/internal/util.py
@@ -244,35 +244,32 @@ def zip_files_stream(local_file_paths, documents=None):
 
     return streaming_generator()
 
-
 def searchRecordForAttributeErrors(document):
     try:
-        attributes = document.get("attributesList", [])
-        i = 0
-        for attribute in attributes:
-            if attribute is not None:
-                if attribute.get("cleaning_error", False):
-                    return True
-                subattributes = attribute.get("subattributes", None)
-                if subattributes:
-                    for subattribute in subattributes:
-                        if subattribute is not None and subattribute.get(
-                            "cleaning_error", False
-                        ):
-                            return True
-            else:
-                _log.info(
-                    f"found none attribute for document {document.get('_id')} at index {i}"
-                )
-                ##TODO: clean this document of null fields. need to write a function for this
-            i += 1
+        attributes = document.get("attributesList") or []
+
+        # Check attributes for errors
+        if any(
+            attr is not None and attr.get("cleaning_error", False)
+            for attr in attributes
+        ):
+            return True
+
+        # Check subattributes for errors
+        if any(
+            sub is not None and sub.get("cleaning_error", False)
+            for attr in attributes if attr is not None
+            for sub in (attr.get("subattributes") or [])
+        ):
+            return True
+
     except Exception as e:
         _log.info(
             f"unable to searchRecordForAttributeErrors for document: {document.get('_id')}"
         )
         _log.info(f"e: {e}")
-    return False
 
+    return False
 
 def convert_processor_attributes_to_dict(attributes):
     attributes_dict = {}

--- a/app/internal/util.py
+++ b/app/internal/util.py
@@ -244,6 +244,7 @@ def zip_files_stream(local_file_paths, documents=None):
 
     return streaming_generator()
 
+
 def searchRecordForAttributeErrors(document):
     try:
         attributes = document.get("attributesList") or []
@@ -258,7 +259,8 @@ def searchRecordForAttributeErrors(document):
         # Check subattributes for errors
         if any(
             sub is not None and sub.get("cleaning_error", False)
-            for attr in attributes if attr is not None
+            for attr in attributes
+            if attr is not None
             for sub in (attr.get("subattributes") or [])
         ):
             return True
@@ -270,6 +272,7 @@ def searchRecordForAttributeErrors(document):
         _log.info(f"e: {e}")
 
     return False
+
 
 def convert_processor_attributes_to_dict(attributes):
     attributes_dict = {}

--- a/app/routers/router.py
+++ b/app/routers/router.py
@@ -278,49 +278,6 @@ async def get_processors(user_info: dict = Depends(authenticate)):
     return resp
 
 
-@router.post("/get_project/{project_id}")
-async def get_project_data(
-    request: Request,
-    project_id: str,
-    page: int = None,
-    records_per_page: int = None,
-    user_info: dict = Depends(authenticate),
-):
-    """Fetch individual project data.
-
-    Args:
-        project_id: Project identifier
-
-    Returns:
-        Dictionary containing project data, list of records
-    """
-    request_body = await request.json()
-    sort_by = request_body.get(
-        "sort", ["dateCreated", 1]
-    )  ## 1 is ascending, -1 is descending`
-    if sort_by[1] != 1 and sort_by[1] != -1:
-        sort_by[1] = 1
-    filter_by = request_body.get("filter", {})
-    project_data, records, record_count = data_manager.fetchProjectData(
-        project_id,
-        user_info.get("email", ""),
-        page,
-        records_per_page,
-        sort_by,
-        filter_by,
-    )
-    if project_data is None:
-        raise HTTPException(
-            403,
-            detail=f"You do not have access to this project, please contact the project creator to gain access.",
-        )
-    return {
-        "project_data": project_data,
-        "records": records,
-        "record_count": record_count,
-    }
-
-
 @router.get("/get_record_group/{rg_id}")
 async def get_record_group_data(
     rg_id: str,


### PR DESCRIPTION
- use aggregation pipeline for fetching record groups (on project page) to get all record groups, plus stats, in one query
   - for 29 ISGS record groups, containing a total of 1873 records, the **speed improved (in local environment) from 13.20 seconds of processing time to 0.86 seconds after updated pipeline**
- time a couple more functions
- update `searchRecordForAttributeErrors` function
- add error catching for fetching column data