### PR TITLE
Reset cleaning error key in the case that an attribute does not have a cleaning function

### DIFF
--- a/ogrre/internal/util.py
+++ b/ogrre/internal/util.py
@@ -426,7 +426,6 @@ def cleanRecordAttribute(processor_attributes, attribute, subattributeKey=None):
         else:
             _log.info(f"no cleaning function with name: {cleaning_function_name}")
 
-
         subattributes = attribute.get("subattributes", None)
         if subattributes:
             for subattribute in subattributes:

--- a/ogrre/internal/util.py
+++ b/ogrre/internal/util.py
@@ -405,6 +405,7 @@ def cleanRecordAttribute(processor_attributes, attribute, subattributeKey=None):
         if cleaning_function_name == "" or cleaning_function_name is None:
             _log.debug(f"cleaning_function for {attribute_key} is empty string or none")
             attribute["cleaned"] = False
+            attribute["cleaning_error"] = False
             return False
         cleaning_function = CLEANING_FUNCTIONS.get(cleaning_function_name)
         if cleaning_function:
@@ -424,6 +425,7 @@ def cleanRecordAttribute(processor_attributes, attribute, subattributeKey=None):
                 attribute["cleaned"] = False
         else:
             _log.info(f"no cleaning function with name: {cleaning_function_name}")
+
 
         subattributes = attribute.get("subattributes", None)
         if subattributes:


### PR DESCRIPTION
- see [UI issue 420](https://github.com/CATALOG-Historic-Records/orphaned-wells-ui/issues/420)