### PR TITLE
Keep attribute field projection consistent across attributes list and subattributes

### DIFF
--- a/ogrre/internal/data_manager.py
+++ b/ogrre/internal/data_manager.py
@@ -1991,7 +1991,7 @@ class DataManager:
                 )
                 writer.writeheader()
                 writer.writerows(record_attributes)
-        else:
+        else:  ## export type is JSON
             for document in records:
                 document_id = str(document["_id"])
                 try:

--- a/ogrre/internal/util.py
+++ b/ogrre/internal/util.py
@@ -586,15 +586,34 @@ def generate_mongo_records_pipeline(
         project = {"$project": {}}
         topLevelFields = include_attribute_fields.get("topLevelFields", [])
         attributesListFields = include_attribute_fields.get("attributesList", [])
+        subtattributesFields = include_attribute_fields.get("subattributes", [])
         for topLevelField in topLevelFields:
             project["$project"][topLevelField] = 1
 
         if len(attributesListFields) > 0:
             attributesList_include = {}
             for attributesListField in attributesListFields:
-                attributesList_include[
-                    attributesListField
-                ] = f"$$attr.{attributesListField}"
+                if (
+                    attributesListField == "subattributes"
+                    and len(subtattributesFields) > 0
+                ):
+                    subattributesList_include = {}
+                    for subtattributesField in subtattributesFields:
+                        subattributesList_include[
+                            subtattributesField
+                        ] = f"$$subattr.{subtattributesField}"
+                    subattributesProject = {
+                        "$map": {
+                            "input": {"$ifNull": ["$$attr.subattributes", []]},
+                            "as": "subattr",
+                            "in": subattributesList_include,
+                        }
+                    }
+                    attributesList_include[attributesListField] = subattributesProject
+                else:
+                    attributesList_include[
+                        attributesListField
+                    ] = f"$$attr.{attributesListField}"
             project["$project"]["attributesList"] = {
                 "$map": {
                     "input": "$attributesList",

--- a/ogrre/routers/router.py
+++ b/ogrre/routers/router.py
@@ -1055,6 +1055,7 @@ async def download_records(
     json_fields_to_include = {
         "topLevelFields": ["name", "filename", "image_files", "record_group_id"],
         "attributesList": ["key", "value", "normalized_vertices", "subattributes"],
+        "subattributes": ["key", "value", "normalized_vertices"],
     }
 
     output_file_id = util.last4_before_decimal()


### PR DESCRIPTION
- add subattributes field projection to mongo pipeline to ensure we keep the same fields for attributeslist and subattributes list