### PR TITLE
dev added method to set options from .json files

### DIFF
--- a/ogrre/internal/util.py
+++ b/ogrre/internal/util.py
@@ -638,7 +638,9 @@ def cleanRecordAttribute(processor_attributes, attribute, subattributeKey=None):
         else:
             cleaning_function = CLEANING_FUNCTIONS.get(cleaning_function_name)
             if cleaning_function:
-                options = attribute_schema.get("options") or {} if attribute_schema else {}
+                options = (
+                    attribute_schema.get("options") or {} if attribute_schema else {}
+                )
                 try:
                     cleaned_val = cleaning_function(unclean_val, options=options)
                     _log.debug(f"CLEANED: {unclean_val} : {cleaned_val}")

--- a/ogrre/internal/util.py
+++ b/ogrre/internal/util.py
@@ -638,8 +638,9 @@ def cleanRecordAttribute(processor_attributes, attribute, subattributeKey=None):
         else:
             cleaning_function = CLEANING_FUNCTIONS.get(cleaning_function_name)
             if cleaning_function:
+                options = attribute_schema.get("options") or {} if attribute_schema else {}
                 try:
-                    cleaned_val = cleaning_function(unclean_val)
+                    cleaned_val = cleaning_function(unclean_val, options=options)
                     _log.debug(f"CLEANED: {unclean_val} : {cleaned_val}")
                     attribute["value"] = cleaned_val
                     attribute["normalized_value"] = cleaned_val


### PR DESCRIPTION
Backend Repo changes to add support for setting cleaning function 'Options' in the schema *json files.
 
It might be worth discussing how we plan to use the 'options' in cleaning functions moving forward, or if this PR is even necessary.   It would definitely be move convenient to have all the data_cleaning logic in the data cleaning repo, so adding support for reading the 'options' from the *.json files would help with that. However, I know we are planning to move away from using the schema *.jsons at some point. Whenever we need to use the 'options' in a cleaning function moving forward, we can either read the 'options' from a given field's *.json or just manually set 'options' for specific fields in the cleanRecords() or cleanRecordAttribute() functions. 

Issue: https://github.com/orgs/CATALOG-Historic-Records/projects/1/views/1?filterQuery=assignee%3A%40me&pane=issue&itemId=225282112&issue=CATALOG-Historic-Records%7Corphaned-wells-ui%7C516
